### PR TITLE
Implements the Combinable behaviour for Bitstrings

### DIFF
--- a/lib/fun_land/builtin/bit_string.ex
+++ b/lib/fun_land/builtin/bit_string.ex
@@ -1,3 +1,7 @@
 defmodule FunLand.Builtin.BitString do
+  use FunLand.Combinable
+
   def neutral, do: ""
+
+  def combine(str_a, str_b), do: Kernel.<>(str_a, str_b) 
 end


### PR DESCRIPTION
This was done before, but for some reason this code was gone from the last version.

This implements the Combinable behaviour for BitStrings, so they can be combined using `Funland.<>` (Just like you're used to from Elixir's standard library).